### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = "index.html"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Digger
 
+[![run on repl.it](http://repl.it/badge/github/lutzroeder/digger)](https://repl.it/github/lutzroeder/digger)
+
 Boulderdash game written in JavaScript using the HTML5 canvas element. 
 
 Use cursor keys, ESC to restart, DEL to jump to the next level.


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-digger):

![image](https://i.imgur.com/n8mjPe6.png)
